### PR TITLE
snort3: try to get  vectorscan and gperftools auto

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   build:
     name: Feeds Package Test Build
-    uses: openwrt/actions-shared-workflows/.github/workflows/multi-arch-test-build.yml@main
+    uses: BKPepe/actions-shared-workflows/.github/workflows/multi-arch-test-build.yml@main

--- a/net/snort3/Config.in
+++ b/net/snort3/Config.in
@@ -1,0 +1,16 @@
+if PACKAGE_snort3
+
+config SNORT3_ENABLE_TCMALLOC
+	bool "Enable tcmalloc"
+	depends on !(powerpc || powerpc64 || mips || mipsel || mips64)
+	default y
+	select PACKAGE_gperftools-runtime
+
+config SNORT3_ENABLE_VECTORSCAN
+	bool "Enable Hyperscan (vectorscan)"
+	depends on (x86_64 || aarch64)
+	default y
+	select PACKAGE_vectorscan-runtime
+
+endif
+

--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -21,15 +21,34 @@ PKG_CPE_ID:=cpe:/a:snort:snort
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
+ifneq ($(findstring powerpc,$(CONFIG_ARCH))$(findstring mips,$(CONFIG_ARCH)),)
+  CMAKE_OPTIONS += \
+	-DENABLE_TCMALLOC=OFF
+else
+  CMAKE_OPTIONS += \
+	-DENABLE_TCMALLOC=ON \
+	-DTCMALLOC_LIBRARIES=$(STAGING_DIR)/usr/lib/libtcmalloc.so
+  EXTRAGP:= +gperftools-runtime
+endif
+
+ifneq ($(findstring x86_64,$(CONFIG_ARCH))$(findstring aarch64,$(CONFIG_ARCH)),)
+  CMAKE_OPTIONS += \
+	-DENABLE_HYPERSCAN=ON \
+	-DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs
+else
+  CMAKE_OPTIONS += \
+	-DENABLE_HYPERSCAN=OFF
+endif
+
 define Package/snort3
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 \
     +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
-    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci \
-    +PACKAGE_gperftools-runtime:gperftools-runtime \
-    +PACKAGE_vectorscan-runtime:vectorscan-runtime
+    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci $(EXTRAGP) \
+    +PACKAGE_snort3&&TARGET_x86_64:vectorscan-runtime \
+    +PACKAGE_snort3&&aarch64:vectorscan-runtime
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1

--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -21,37 +21,22 @@ PKG_CPE_ID:=cpe:/a:snort:snort
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-ifneq ($(findstring powerpc,$(CONFIG_ARCH))$(findstring mips,$(CONFIG_ARCH)),)
-  CMAKE_OPTIONS += \
-	-DENABLE_TCMALLOC=OFF
-else
-  CMAKE_OPTIONS += \
-	-DENABLE_TCMALLOC=ON \
-	-DTCMALLOC_LIBRARIES=$(STAGING_DIR)/usr/lib/libtcmalloc.so
-  EXTRAGP:= +gperftools-runtime
-endif
-
-ifneq ($(findstring x86_64,$(CONFIG_ARCH))$(findstring aarch64,$(CONFIG_ARCH)),)
-  CMAKE_OPTIONS += \
-	-DENABLE_HYPERSCAN=ON \
-	-DHS_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/hs
-else
-  CMAKE_OPTIONS += \
-	-DENABLE_HYPERSCAN=OFF
-endif
-
 define Package/snort3
   SUBMENU:=Firewall
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+libstdcpp +libdaq3 +libdnet +libopenssl +libpcap +libpcre2 \
     +libpthread +libuuid +zlib +libhwloc +libtirpc @HAS_LUAJIT_ARCH +luajit +libatomic \
-    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci $(EXTRAGP) \
-    +PACKAGE_snort3&&TARGET_x86_64:vectorscan-runtime \
-    +PACKAGE_snort3&&aarch64:vectorscan-runtime
+    +kmod-nft-queue +liblzma +ucode +ucode-mod-fs +ucode-mod-uci \
+    $(if $(CONFIG_SNORT3_ENABLE_TCMALLOC),+gperftools-runtime) \
+    $(if $(CONFIG_SNORT3_ENABLE_VECTORSCAN),+vectorscan-runtime)
   TITLE:=Lightweight Network Intrusion Detection System
   URL:=http://www.snort.org/
   MENU:=1
+endef
+
+define Package/snort3/config
+  source "$(SOURCE)/Config.in"
 endef
 
 define Package/snort3/description


### PR DESCRIPTION
Trying to autoselect based on simply selecting the snort3 package. Right now, only gperftools-runtime works.

**Package details**

    Maintainer: @\<github-user> (find it by checking the history of the package Makefile)
    Description:

**Indication of run testing**

     OpenWrt version:
     OpenWrt target/subtarget:
     OpenWrt device:

**Formalities**

     [ ] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

     If your PR contains a patch
     [ ] Make sure that it can be applied by `git am`
     [ ] It must be refreshed to avoid offsets, fuzzes, etc by `make package/foo/refresh V=s`
     [ ] It must be in a way that it is potentially upstreamable (subject, commit description, etc.), and we must try to upstream it so we have fewer patches and fewer.
